### PR TITLE
MFMailComposeViewController can't be presented over modal

### DIFF
--- a/ios/RNMailCompose/RNMailCompose.swift
+++ b/ios/RNMailCompose/RNMailCompose.swift
@@ -82,7 +82,11 @@ class RNMailCompose: NSObject, MFMailComposeViewControllerDelegate {
     self.resolve = resolve
     self.reject = reject
     
-    UIApplication.shared.keyWindow?.rootViewController?.present(vc, animated: true, completion: nil)
+    var rootVC = UIApplication.shared.keyWindow?.rootViewController;
+    while (rootVC?.presentedViewController != nil) {
+      rootVC = rootVC?.presentedViewController;
+    }
+    rootVC?.present(vc, animated: true, completion: nil)
   }
   
   func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {


### PR DESCRIPTION
MFMailComposeViewController isn't displayed when a React Native Modal is already presented. This pull request fixes this issue.