### PR TITLE
Fixed function signature for `canSendMail`

### DIFF
--- a/ios/RNMailCompose/RNMailCompose.swift
+++ b/ios/RNMailCompose/RNMailCompose.swift
@@ -21,7 +21,7 @@ class RNMailCompose: NSObject, MFMailComposeViewControllerDelegate {
     ]
   }
   
-  @objc func canSendMail(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+  @objc func canSendMail(_ resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     return resolve(MFMailComposeViewController.canSendMail())
   }
   

--- a/ios/RNMailCompose/RNMailComposeBridge.m
+++ b/ios/RNMailCompose/RNMailComposeBridge.m
@@ -14,8 +14,7 @@
 
 @interface RCT_EXTERN_MODULE(RNMailCompose, NSObject)
 
-RCT_EXTERN_METHOD(canSendMail:
-                  resolve:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(canSendMail:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(send:(NSDictionary *)data


### PR DESCRIPTION
The signature of canSendMail is incorrect and causes a runtime error when the function is called from JavaScript code. This pull request fixes the issue.