### PR TITLE
Create a podspec

### DIFF
--- a/react-native-mail-compose.podspec
+++ b/react-native-mail-compose.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "react-native-mail-compose"
+  s.version      = "0.0.3"
+  s.summary      = "React Native library for composing email. Wraps MFMailComposeViewController for iOS and Intent for Android."
+  s.requires_arc = true
+  s.license      = 'MIT'
+  s.homepage     = 'https://github.com/joonhocho/react-native-mail-compose'
+  s.author       = "Joon Ho Cho"
+  s.source       = { :git => "https://github.com/joonhocho/react-native-mail-compose.git" }
+  s.source_files = 'ios/**/*.{h,m,swift}'
+  s.platform     = :ios, "8.0"
+  s.dependency 'React/Core'
+end


### PR DESCRIPTION
Native apps that use components build with RN need to link with 3rd party RN libraries that contain native code. This is usually done using Cocoapods and most libraries will include a podspec to support this.

I have created a podspec with a few sensible settings. Ideally we should add a tag for the source property.

You don't have to publish the podspec on the public Cocoapods repo. Since react-native-mail-compose is already installed via npm the podspec can be referred to locally.