### PR TITLE
 Use FileProvider.getUriForFile() for Android 7.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,38 @@ public class MainApplication extends Application implements ReactApplication {
     }
 ```
 
+## Additional setup for Android 7.0+
+If your app's `targetSdk` is 24 or higher, [FileProvider](https://developer.android.com/training/secure-file-sharing/setup-sharing) is used when attaching files.
+So, you have to set up FileProvider for your app.
+
+In your app's `AndroidManifest.xml` add `<provider>` 
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.myapp">
+    <application
+        ...>
+      <provider
+          android:name="android.support.v4.content.FileProvider"
+          android:authorities="${applicationId}.provider"
+          android:exported="false"
+          android:grantUriPermissions="true">
+          <meta-data
+              android:name="android.support.FILE_PROVIDER_PATHS"
+              android:resource="@xml/provider_paths"/>
+      </provider>
+        ...
+    </application>
+</manifest>
+```
+
+And in your app's `res/xml` create `provider_paths.xml` with the following content
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+  <external-path name="external_files" path="."/>
+</paths>
+```
+
 ## iOS (Required)
 These steps MUST be done manually. They are NOT done by `react-native install`.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.0"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/src/main/java/com/reactlibrary/mailcompose/RNMailComposeModule.java
+++ b/android/src/main/java/com/reactlibrary/mailcompose/RNMailComposeModule.java
@@ -185,7 +185,7 @@ public class RNMailComposeModule extends ReactContextBaseJavaModule {
 
     private byte[] getBlob(ReadableMap map, String key) {
         if (map.hasKey(key) && map.getType(key) == ReadableType.String) {
-            String base64 = map.getString(key);Uri
+            String base64 = map.getString(key);
             if (base64 != null && !base64.isEmpty()) {
                 return Base64.decode(base64, 0);
             }

--- a/android/src/main/java/com/reactlibrary/mailcompose/RNMailComposeModule.java
+++ b/android/src/main/java/com/reactlibrary/mailcompose/RNMailComposeModule.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.text.Html;
 import android.text.Spanned;
 import android.util.Base64;
+import android.support.v4.content.FileProvider;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.BaseActivityEventListener;
@@ -123,7 +124,12 @@ public class RNMailComposeModule extends ReactContextBaseJavaModule {
                     }
 
                     if (tempFile != null) {
-                        uris.add(Uri.fromFile(tempFile));
+                        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.N){
+                            uris.add(Uri.fromFile(tempFile));
+                        }else{
+                            uris.add(FileProvider.getUriForFile(this.getReactApplicationContext(),
+                                    this.getReactApplicationContext().getPackageName() + ".provider", tempFile));
+                        }
                     }
                 }
             }
@@ -179,7 +185,7 @@ public class RNMailComposeModule extends ReactContextBaseJavaModule {
 
     private byte[] getBlob(ReadableMap map, String key) {
         if (map.hasKey(key) && map.getType(key) == ReadableType.String) {
-            String base64 = map.getString(key);
+            String base64 = map.getString(key);Uri
             if (base64 != null && !base64.isEmpty()) {
                 return Base64.decode(base64, 0);
             }


### PR DESCRIPTION
For apps targeting 24(Android Nougat) or higher, FileProvider is required for grating file sharing access. using `Uri.fromFile()` dose not works on api 24 higher. 

This patch make module to call `FileProvider.getUriForFile()` for api 24+ and call `Uri.fromFile()` if api is lower then 24.

This patch also includes additional documentation for setting up FileProvider

Tested on OnePlus 3T with Android 8.0 installed